### PR TITLE
Replace whitespaces in project name, fixes #14

### DIFF
--- a/inceptalytics/analytics.py
+++ b/inceptalytics/analytics.py
@@ -32,7 +32,7 @@ class Project:
         client = Pycaprio(remote_url, authentication=auth)
 
         if isinstance(project, str):
-            project = project.replace(" ", "-")
+            project = project.replace(" ", "-").lower()
             projects = [p for p in client.api.projects() if p.project_name == project]
 
             if len(projects) == 0:

--- a/inceptalytics/analytics.py
+++ b/inceptalytics/analytics.py
@@ -32,7 +32,7 @@ class Project:
         client = Pycaprio(remote_url, authentication=auth)
 
         if isinstance(project, str):
-            project.replace(" ", "-")
+            project = project.replace(" ", "-")
             projects = [p for p in client.api.projects() if p.project_name == project]
 
             if len(projects) == 0:

--- a/inceptalytics/analytics.py
+++ b/inceptalytics/analytics.py
@@ -40,7 +40,7 @@ class Project:
 
             project = projects[0]
 
-        zip_content = client.api.export_project(project, InceptionFormat.XMI)
+        zip_content = client.api.export_project(project, InceptionFormat.UIMA_CAS_XMI)
         return cls.from_zipped_xmi(BytesIO(zip_content))
 
     @classmethod

--- a/inceptalytics/analytics.py
+++ b/inceptalytics/analytics.py
@@ -32,6 +32,7 @@ class Project:
         client = Pycaprio(remote_url, authentication=auth)
 
         if isinstance(project, str):
+            project.replace(" ", "-")
             projects = [p for p in client.api.projects() if p.project_name == project]
 
             if len(projects) == 0:


### PR DESCRIPTION
The presence of whitespace in the project's name is automatically converted to a minus/hyphen behind the scenes of INCEPTION, as far as I can tell.